### PR TITLE
Clarify custom code configuration [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1027,7 +1027,7 @@ NOTE. If you are running in a multi-threaded environment, there could be a chanc
 Custom configuration
 --------------------
 
-You can configure your own code through the Rails configuration object with custom configuration. It works like this:
+You can configure your own code through the Rails configuration object with custom configuration under the `config.x` property. It works like this:
 
   ```ruby
   config.x.payment_processing.schedule = :daily


### PR DESCRIPTION
Reader of the guide could easily overlook the need of putting their custom configuration under `config.x` property. This pull request tries to remedy this by pointing it out.
